### PR TITLE
Add configuration and policy to restrict creation of expensive instances

### DIFF
--- a/all-containers-must-have-resource-limits/metadata.yml
+++ b/all-containers-must-have-resource-limits/metadata.yml
@@ -1,5 +1,5 @@
 name: "All Containers Must Have Resource Limits"
-description: "Ensures that all containers in Kubernetes workloads (deployments, statefulsets, daemonsets, jobs, cronjobs, and pods) have CPU and memory limits set, preventing resource contention and ensuring cluster stability."
+description: "Ensures that all containers in Kubernetes workloads have CPU and memory limits set, preventing resource contention and ensuring cluster stability."
 categories:
   - "Cost"
 tags:

--- a/restrict-creation-of-expensive-instance-types/configurationSchema.json
+++ b/restrict-creation-of-expensive-instance-types/configurationSchema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Restrict Creation of Expensive Instance Types Configuration",
+  "type": "object",
+  "properties": {
+    "disallowed_patterns": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of instance type patterns to disallow (e.g., ['*.metal', 'g5.*'])",
+      "examples": [
+        ["*.metal", "g5.*"],
+        ["x1e.*", "r5.24xlarge", "m5*.metal"]
+      ]
+    }
+  },
+  "required": ["disallowed_patterns"],
+  "additionalProperties": false
+}

--- a/restrict-creation-of-expensive-instance-types/configurationSchema.json
+++ b/restrict-creation-of-expensive-instance-types/configurationSchema.json
@@ -8,7 +8,7 @@
       "items": {
         "type": "string"
       },
-      "description": "List of instance type patterns to disallow (e.g., ['*.metal', 'g5.*'])",
+      "description": "List of instance type patterns to disallow (e.g., [\"*.metal\", \"g5.*\"])",
       "examples": [
         ["*.metal", "g5.*"],
         ["x1e.*", "r5.24xlarge", "m5*.metal"]

--- a/restrict-creation-of-expensive-instance-types/metadata.yml
+++ b/restrict-creation-of-expensive-instance-types/metadata.yml
@@ -1,0 +1,10 @@
+name: "Restrict Creation of Expensive Instance Types"
+description: "Prevents accidental or unauthorized provisioning of high-cost instance types, helping to control cloud spend."
+categories:
+  - "Cost"
+  - "Governance"
+tags:
+  - "EC2"
+  - "VM"
+  - "Cost"
+cloudProvider: "aws"

--- a/restrict-creation-of-expensive-instance-types/policy.rego
+++ b/restrict-creation-of-expensive-instance-types/policy.rego
@@ -1,7 +1,8 @@
 package env0
 
 deny[msg] {
-    pattern := input.policyData.disallowed_patterns[_]
+    patterns := ["*.metal", "g5.*"]
+    pattern := patterns[_]
     r := input.plan.resource_changes[_]
     r.type == "aws_instance"
     glob.match(pattern, [], r.change.after.instance_type)

--- a/restrict-creation-of-expensive-instance-types/policy.rego
+++ b/restrict-creation-of-expensive-instance-types/policy.rego
@@ -1,4 +1,4 @@
-package env0.policy
+package env0
 
 deny[msg] {
     pattern := input.policyData.disallowed_patterns[_]

--- a/restrict-creation-of-expensive-instance-types/policy.rego
+++ b/restrict-creation-of-expensive-instance-types/policy.rego
@@ -1,8 +1,7 @@
 package env0
 
 deny[msg] {
-    patterns := ["*.metal", "g5.*"]
-    pattern := patterns[_]
+    pattern := input.policyData.disallowed_patterns[_]
     r := input.plan.resource_changes[_]
     r.type == "aws_instance"
     glob.match(pattern, [], r.change.after.instance_type)

--- a/restrict-creation-of-expensive-instance-types/policy.rego
+++ b/restrict-creation-of-expensive-instance-types/policy.rego
@@ -1,0 +1,9 @@
+package env0.policy
+
+deny[msg] {
+    pattern := input.policyData.disallowed_patterns[_]
+    r := input.plan.resource_changes[_]
+    r.type == "aws_instance"
+    glob.match(pattern, [], r.change.after.instance_type)
+    msg := "Creation of expensive instance types is restricted."
+}


### PR DESCRIPTION
- Introduced a JSON schema for configuration specifying disallowed instance type patterns.
- Added metadata for the new policy to prevent unauthorized provisioning of high-cost instance types.
- Implemented a Rego policy to enforce restrictions on the creation of specified instance types in AWS.

on error:
<img width="735" height="533" alt="image" src="https://github.com/user-attachments/assets/eaef5679-f73c-4397-bf8f-19a0dd3bdcb5" />
