### PR TITLE
Add Prohibit Use of Default VPC Policy

### DIFF
--- a/prohibit-default-vpc/configurationSchema.json
+++ b/prohibit-default-vpc/configurationSchema.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "enforcementMode": {
+      "type": "string",
+      "title": "Enforcement Mode",
+      "description": "Whether to monitor or enforce this policy",
+      "enum": ["monitor", "enforce"],
+      "default": "enforce"
+    }
+  },
+  "required": ["enforcementMode"]
+}

--- a/prohibit-default-vpc/metadata.yml
+++ b/prohibit-default-vpc/metadata.yml
@@ -1,0 +1,9 @@
+name: "Prohibit Use of Default VPC"
+description: "Discourages use of the default VPC to promote intentional, segmented network design."
+categories:
+  - "Security"
+  - "Networking"
+tags:
+  - "VPC"
+  - "Best Practice"
+cloudProvider: "aws"

--- a/prohibit-default-vpc/policy.rego
+++ b/prohibit-default-vpc/policy.rego
@@ -1,0 +1,8 @@
+package env0.policy
+
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "aws_instance"
+    r.change.after.vpc_security_group_ids == null
+    msg := "Do not use the default VPC; explicitly define one."
+}


### PR DESCRIPTION
## Policy Details

**Policy Name:** Prohibit Use of Default VPC

**Description:** Discourages use of the default VPC to promote intentional, segmented network design.

**Cloud Provider:** AWS

**Category:** Security, Networking

**Relevant Tags:** VPC, Best Practice

## Implementation

This policy implements the Rego logic to detect AWS instances that are using the default VPC (indicated by `vpc_security_group_ids == null`).

### Files Added:
- `prohibit-default-vpc/metadata.yml` - Policy metadata and configuration
- `prohibit-default-vpc/policy.rego` - Rego policy logic
- `prohibit-default-vpc/configurationSchema.json` - Configuration schema

### Rego Logic:
```rego
package env0.policy

deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "aws_instance"
    r.change.after.vpc_security_group_ids == null
    msg := "Do not use the default VPC; explicitly define one."
}
```

This policy will trigger when:
1. An AWS instance is being created/modified
2. The instance doesn't have explicit VPC security groups defined (using default VPC)

## Testing

The policy should be tested with:
1. AWS instances without explicit VPC security groups (should fail)
2. AWS instances with explicitly defined VPC security groups (should pass)

Closes ENG-348