### PR TITLE
Add RDS Instances Must Not Be Publicly Accessible Policy

### DIFF
--- a/rds-instances-must-not-be-publicly-accessible/metadata.yml
+++ b/rds-instances-must-not-be-publicly-accessible/metadata.yml
@@ -1,0 +1,10 @@
+name: "RDS Instances Must Not Be Publicly Accessible"
+description: "Ensures databases are not exposed directly to the internet, requiring connections through a secure bastion or VPC."
+categories:
+  - "Security"
+  - "Networking"
+tags:
+  - "RDS"
+  - "Database"
+  - "Security"
+cloudProvider: "aws"

--- a/rds-instances-must-not-be-publicly-accessible/policy.rego
+++ b/rds-instances-must-not-be-publicly-accessible/policy.rego
@@ -1,0 +1,18 @@
+package env0.policy
+
+# Deny RDS instances that are publicly accessible
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "aws_db_instance"
+    "create" in r.change.actions
+    r.change.after.publicly_accessible == true
+    msg := "RDS instances must not be publicly accessible."
+}
+
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "aws_db_instance"
+    "update" in r.change.actions
+    r.change.after.publicly_accessible == true
+    msg := "RDS instances must not be publicly accessible."
+}


### PR DESCRIPTION
## Policy Details

**Policy Name:** RDS Instances Must Not Be Publicly Accessible

**Description:** Ensures databases are not exposed directly to the internet, requiring connections through a secure bastion or VPC.

**Cloud Provider:** AWS

**Category:** Security, Networking

**Relevant Tags:** RDS, Database, Security

## Implementation

This policy implements Rego logic to prevent RDS instances from being publicly accessible, ensuring database security.

### Files Added:
- `rds-instances-must-not-be-publicly-accessible/metadata.yml` - Policy metadata and configuration
- `rds-instances-must-not-be-publicly-accessible/policy.rego` - Rego policy logic

### Security Features Enforced:

#### **Database Security:**
- ✅ **Public Accessibility Prevention**: Blocks RDS instances with `publicly_accessible = true`
- ✅ **Network Security**: Ensures databases are only accessible through VPC
- ✅ **Database Engine Support**: Works with all RDS engines (MySQL, PostgreSQL, Oracle, etc.)

### Rego Logic:
```rego
package env0.policy

# Deny RDS instances that are publicly accessible
deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "aws_db_instance"
    "create" in r.change.actions
    r.change.after.publicly_accessible == true
    msg := "RDS instances must not be publicly accessible."
}

deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "aws_db_instance"
    "update" in r.change.actions
    r.change.after.publicly_accessible == true
    msg := "RDS instances must not be publicly accessible."
}
```

This policy will trigger when:
1. An AWS RDS instance is being created/modified
2. The `publicly_accessible` attribute is set to `true`
3. The policy only applies to CREATE and UPDATE operations, not DESTROY operations

## Testing

Comprehensive test templates are available in: [env0/integration-templates#35](https://github.com/env0/integration-templates/pull/35)

### Test Cases:
- **Fail Test**: RDS instance with `publicly_accessible = true` (should be blocked)
- **Pass Test**: RDS instance with `publicly_accessible = false` (should be allowed)

## Related

- Linear Ticket: ENG-347
- Test Templates: [env0/integration-templates#35](https://github.com/env0/integration-templates/pull/35)