### PR TITLE
Add EBS Volumes Must Be Encrypted Policy

### DIFF
--- a/ebs-volumes-must-be-encrypted/metadata.yml
+++ b/ebs-volumes-must-be-encrypted/metadata.yml
@@ -1,0 +1,10 @@
+name: "EBS Volumes Must Be Encrypted"
+description: "Mandates that all Elastic Block Store (EBS) volumes attached to EC2 instances are encrypted."
+categories:
+  - "Security"
+  - "Compliance"
+tags:
+  - "EBS"
+  - "Encryption"
+  - "Security"
+cloudProvider: "aws"

--- a/ebs-volumes-must-be-encrypted/policy.rego
+++ b/ebs-volumes-must-be-encrypted/policy.rego
@@ -1,0 +1,10 @@
+package env0.policy
+
+# Deny EBS volumes that are not encrypted
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "aws_ebs_volume"
+    ("create" in r.change.actions or "update" in r.change.actions)
+    r.change.after.encrypted != true
+    msg := "EBS volumes must be encrypted."
+}


### PR DESCRIPTION
## Policy Details

**Policy Name:** EBS Volumes Must Be Encrypted

**Description:** Mandates that all Elastic Block Store (EBS) volumes attached to EC2 instances are encrypted.

**Cloud Provider:** AWS

**Category:** Security, Compliance

**Relevant Tags:** EBS, Encryption, Security

## Implementation

This policy implements Rego logic to enforce EBS volume encryption, ensuring data at rest security.

### Files Added:
- `ebs-volumes-must-be-encrypted/metadata.yml` - Policy metadata and configuration
- `ebs-volumes-must-be-encrypted/policy.rego` - Rego policy logic

### Security Features Enforced:

#### **Data Protection:**
- ✅ **EBS Encryption**: Blocks EBS volumes with `encrypted = false`
- ✅ **Data at Rest Security**: Ensures all EBS volumes are encrypted
- ✅ **Volume Type Support**: Works with all EBS volume types (gp3, gp2, io1, io2, st1, sc1)
- ✅ **KMS Integration**: Supports custom KMS keys for encryption

### Rego Logic:
```rego
package env0.policy

# Deny EBS volumes that are not encrypted
deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "aws_ebs_volume"
    ("create" in r.change.actions or "update" in r.change.actions)
    r.change.after.encrypted != true
    msg := "EBS volumes must be encrypted."
}
```

This policy will trigger when:
1. An AWS EBS volume is being created/modified
2. The `encrypted` attribute is not set to `true`
3. The policy only applies to CREATE and UPDATE operations, not DESTROY operations

## Testing

Comprehensive test templates are available in: [env0/integration-templates#36](https://github.com/env0/integration-templates/pull/36)

### Test Cases:
- **Fail Test**: EBS volume with `encrypted = false` (should be blocked)
- **Pass Test**: EBS volume with `encrypted = true` (should be allowed)

## Related

- Linear Ticket: ENG-357
- Test Templates: [env0/integration-templates#36](https://github.com/env0/integration-templates/pull/36)