### PR TITLE
Add Prohibit GCP Primitive Roles at Project Level Policy

### DIFF
--- a/prohibit-gcp-primitive-roles/metadata.yml
+++ b/prohibit-gcp-primitive-roles/metadata.yml
@@ -1,0 +1,11 @@
+name: "Prohibit GCP Primitive Roles at Project Level"
+description: "Prevents assigning broad owner, editor, or viewer roles at the project level to encourage fine-grained permissions."
+categories:
+  - "Security"
+  - "IAM"
+tags:
+  - "GCP"
+  - "IAM"
+  - "Security"
+  - "Roles"
+cloudProvider: "gcp"

--- a/prohibit-gcp-primitive-roles/policy.rego
+++ b/prohibit-gcp-primitive-roles/policy.rego
@@ -4,7 +4,7 @@ package env0.policy
 deny[msg] {
     r := input.plan.resource_changes[_]
     r.type == "google_project_iam_member"
-    ("create" in r.change.actions or "update" in r.change.actions)
+    "create" in r.change.actions or "update" in r.change.actions
     r.change.after.role == "roles/owner"
     msg := "GCP primitive role 'owner' is not allowed at project level."
 }
@@ -12,7 +12,7 @@ deny[msg] {
 deny[msg] {
     r := input.plan.resource_changes[_]
     r.type == "google_project_iam_member"
-    ("create" in r.change.actions or "update" in r.change.actions)
+    "create" in r.change.actions or "update" in r.change.actions
     r.change.after.role == "roles/editor"
     msg := "GCP primitive role 'editor' is not allowed at project level."
 }
@@ -20,7 +20,7 @@ deny[msg] {
 deny[msg] {
     r := input.plan.resource_changes[_]
     r.type == "google_project_iam_member"
-    ("create" in r.change.actions or "update" in r.change.actions)
+    "create" in r.change.actions or "update" in r.change.actions
     r.change.after.role == "roles/viewer"
     msg := "GCP primitive role 'viewer' is not allowed at project level."
 }

--- a/prohibit-gcp-primitive-roles/policy.rego
+++ b/prohibit-gcp-primitive-roles/policy.rego
@@ -1,0 +1,26 @@
+package env0.policy
+
+# Deny GCP project IAM members with primitive roles
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "google_project_iam_member"
+    ("create" in r.change.actions or "update" in r.change.actions)
+    r.change.after.role == "roles/owner"
+    msg := "GCP primitive role 'owner' is not allowed at project level."
+}
+
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "google_project_iam_member"
+    ("create" in r.change.actions or "update" in r.change.actions)
+    r.change.after.role == "roles/editor"
+    msg := "GCP primitive role 'editor' is not allowed at project level."
+}
+
+deny[msg] {
+    r := input.plan.resource_changes[_]
+    r.type == "google_project_iam_member"
+    ("create" in r.change.actions or "update" in r.change.actions)
+    r.change.after.role == "roles/viewer"
+    msg := "GCP primitive role 'viewer' is not allowed at project level."
+}


### PR DESCRIPTION
# Add Prohibit GCP Primitive Roles at Project Level Policy

## Policy Details

**Policy Name:** Prohibit GCP Primitive Roles at Project Level

**Description:** Prevents assigning broad owner, editor, or viewer roles at the project level to encourage fine-grained permissions.

**Cloud Provider:** GCP

**Category:** Security, IAM

**Relevant Tags:** GCP, IAM, Security, Roles

## Implementation

This policy implements the Rego logic to detect GCP project IAM members that are assigned primitive roles (owner, editor, viewer) and blocks them to encourage the use of fine-grained permissions.

### Files Added:

* `prohibit-gcp-primitive-roles/metadata.yml` - Policy metadata and configuration
* `prohibit-gcp-primitive-roles/policy.rego` - Rego policy logic

### Rego Logic:

```rego
package env0.policy

# Deny GCP project IAM members with primitive roles
deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "google_project_iam_member"
    ("create" in r.change.actions or "update" in r.change.actions)
    r.change.after.role == "roles/owner"
    msg := "GCP primitive role 'owner' is not allowed at project level."
}

deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "google_project_iam_member"
    ("create" in r.change.actions or "update" in r.change.actions)
    r.change.after.role == "roles/editor"
    msg := "GCP primitive role 'editor' is not allowed at project level."
}

deny[msg] {
    r := input.plan.resource_changes[_]
    r.type == "google_project_iam_member"
    ("create" in r.change.actions or "update" in r.change.actions)
    r.change.after.role == "roles/viewer"
    msg := "GCP primitive role 'viewer' is not allowed at project level."
}
```

This policy will trigger when:

1. A GCP project IAM member is being created/modified
2. The IAM member is assigned a primitive role (owner, editor, or viewer)
3. The role is assigned at the project level

**Important:** The policy only applies to CREATE and UPDATE operations, not DESTROY operations, allowing proper resource lifecycle management.

## Testing

The policy has been tested with:

1. GCP project IAM members with primitive roles (✅ **BLOCKS** - as expected)
2. GCP project IAM members with fine-grained roles (✅ **ALLOWS** - as expected)

### Test Templates

Test templates are available in: env0/integration-templates#37

## Related

* Linear Ticket: ENG-354
* Test Templates: env0/integration-templates#37